### PR TITLE
Remove white space in cookiecutter slug curly braces

### DIFF
--- a/{{cookiecutter.project_slug}}/environment.yml
+++ b/{{cookiecutter.project_slug}}/environment.yml
@@ -1,4 +1,4 @@
-name: { { cookiecutter.project_slug } }
+name: {{ cookiecutter.project_slug }}
 channels:
   - anaconda
   - conda-forge


### PR DESCRIPTION
Here's a pull request to remove the white space in the template environment.yml.

Fixes #1 